### PR TITLE
Add ability for custom swap API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,6 @@ Open `localhost:3000` in your browser. The swap is at `localhost:3000/swap`
 
 ### API Implementation
 The API implementation is at [create-solana-dapp/web/app/swap/page.tsx](https://github.com/AlmostEfficient/jupiter-swap/blob/main/create-solana-dapp/web/app/swap/page.tsx). It's configured to only have 4 assets - USDC, SOL, BONK, WIF. You'll need to add your own token mint addresses, or you can use the [token list API](https://station.jup.ag/docs/token-list/token-list-api) for validated tokens.
+
+### Using custom Swap API endpoints
+You can get Swap API urls from [Jupiter Station](https://station.jup.ag/docs/apis/swap-api), [QuickNode](https://marketplace.quicknode.com/add-on/metis-jupiter-v6-swap-api) or [JupiterAPI.com](https://www.jupiterapi.com/). You can easily update the Swap API for the endpoints at [create-solana-dapp/web/app/swap/page.tsx](https://github.com/AlmostEfficient/jupiter-swap/blob/main/create-solana-dapp/web/app/swap/page.tsx) and [create-solana-dapp/web/app/api/swap/route.ts](https://github.com/AlmostEfficient/jupiter-swap/blob/main/create-solana-dapp/web/app/api/swap/route.ts).

--- a/create-solana-dapp/web/app/api/swap/route.ts
+++ b/create-solana-dapp/web/app/api/swap/route.ts
@@ -9,7 +9,7 @@ export async function POST(request: Request) {
   console.log('Request to swap from', userPublicKey)
   
   try {
-    const swapTxResponse = await fetch('https://quote-api.jup.ag/v6/swap', {
+    const swapTxResponse = await fetch('https://public.jupiterapi.com/swap', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/create-solana-dapp/web/app/swap/page.tsx
+++ b/create-solana-dapp/web/app/swap/page.tsx
@@ -77,7 +77,7 @@ export default function Swap() {
 
     const quote = await (
       await fetch(
-        `https://quote-api.jup.ag/v6/quote?inputMint=${fromAsset.mint}&outputMint=${toAsset.mint}&amount=${currentAmount * Math.pow(10, fromAsset.decimals)}&slippage=0.5`
+        `https://public.jupiterapi.com/quote?inputMint=${fromAsset.mint}&outputMint=${toAsset.mint}&amount=${currentAmount * Math.pow(10, fromAsset.decimals)}&slippage=0.5`
       )
     ).json();
 
@@ -100,7 +100,7 @@ export default function Swap() {
 
     // get serialized transactions for the swap
     const { swapTransaction } = await (
-      await fetch('https://quote-api.jup.ag/v6/swap', {
+      await fetch('https://public.jupiterapi.com/swap', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
This PR adjusts the default API used for swap/quote to leverage [jupiterapi.com](https://www.jupiterapi.com/). The API offers higher rate limits along with a faster updated market cache. The [jupiterapi.com](https://www.jupiterapi.com/) market cache surfaces newly launched tokens faster since it doesn't require a certain volume/liquidity threshold to be met, along with an improved cadence of it being updated. While this repo has a fixed set of assets, the API will be useful for those that opt to validate tokens via the token list API. With that said, the API does take a small fee on swaps given the stability/rate limits/new markets it provides. More details can be found on their site.

I also updated the README.md to provide options to other endpoints in case higher rate limits are needed.